### PR TITLE
add repoze.workflow.has_permission

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,23 @@
 repoze.workflow Changelog
 =========================
 
+1.0b2 (unreleased)
+------------------
+
+Features
+~~~~~~~~
+
+- Add ``repoze.workflow.has_permission`` since as of Pyramid 1.5 the
+  "pyramid.security.has_permission" API is now deprecated and it will
+  be removed in Pyramid 1.8
+
+Housekeeping
+~~~~~~~~~~~~
+
+- Update permission checker example in ``docs/configuration.rst``
+
+- Add mock library to test requirements
+
 1.0b1 (2014-12-11)
 ------------------
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -64,7 +64,7 @@ workflow.
       state_attr="state"
       initial_state="private"
       content_types=".dummy.IContent"
-      permission_checker="repoze.bfg.security.has_permission"
+      permission_checker="repoze.workflow.has_permission"
       >
 
       <state name="private" 

--- a/repoze/workflow/__init__.py
+++ b/repoze/workflow/__init__.py
@@ -1,3 +1,4 @@
+from repoze.workflow.security import has_permission # API
 from repoze.workflow.workflow import Workflow # API
 from repoze.workflow.workflow import WorkflowError #API
 from repoze.workflow.workflow import get_workflow #API

--- a/repoze/workflow/security.py
+++ b/repoze/workflow/security.py
@@ -1,0 +1,5 @@
+def has_permission(permission, context, request):
+    """ Default permission checker """
+    return request.has_permission(
+        permission,
+        context=context)

--- a/repoze/workflow/tests/test_security.py
+++ b/repoze/workflow/tests/test_security.py
@@ -1,0 +1,20 @@
+import unittest
+
+
+class HasPermissionTests(unittest.TestCase):
+
+    def _get_has_permission(self):
+        from repoze.workflow import has_permission
+        return has_permission
+
+    def test_has_permission(self):
+        import mock
+        has_permission = self._get_has_permission()
+        permission = 'edit'
+        context = object()
+        request = mock.MagicMock()
+        has_permission(permission, context, request)
+        self.assertEqual(
+            request.has_permission.assert_called_once_with(
+                permission, context=context),
+            None)

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ requires = [
 
 tests_require = [
     'zope.testing',
+    'mock',
     ]
 
 testing_extras = tests_require + ['nose', 'coverage']


### PR DESCRIPTION
Many pyramid applications are using the deprecated ``pyramid.security.has_permission`` API:

> DeprecationWarning: has_permission: As of Pyramid 1.5 the "pyramid.security.has_permission" API is now deprecated.  It will be removed in Pyramid 1.8.  Use the "has_permission" method of the Pyramid request instead.

This PR add a ``repoze.workflow.has_permission`` (defined in the ``repoze.workflow.security`` module) that invokes ``request.has_permission`` so people using the deprecated permission checker will be able to avoid the deprecation using the one provided by repoze.workflow.

cc: @disko