### PR TITLE
Roles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ repoze.workflow Changelog
 1.1 (2020-07-01)
 ----------------
 
+- support for role guards in transitions
 - Add support for Python 3.5, 3.6, 3.7, and 3.8.
 
 Backward-Incompatible Changes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,12 +4,12 @@ repoze.workflow Changelog
 1.2 (unreleased)
 ----------------
 
+- support for role guards in transitions
 - TBD
 
 1.1 (2020-07-01)
 ----------------
 
-- support for role guards in transitions
 - Add support for Python 3.5, 3.6, 3.7, and 3.8.
 
 Backward-Incompatible Changes

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -95,6 +95,14 @@ workflow.
          permission="moderate"
          />
 
+      <transition
+         name="private_to_public_by_role"
+         from_state="private"
+         to_state="public">
+            <role name="admin"/>
+            <role name="editor"/>
+      </transition>
+
    </workflow>
          
    </configure>
@@ -163,6 +171,14 @@ attributes:
   string), ``context`` and ``request``.  It should return ``True`` if
   the current user implied by the request has the permission in the
   ``context``, ``False`` otherwise.
+
+``roles_checker``
+
+  A Python dotted-name referring to a permission checking function.
+  This function should accept three arguments: ``roles`` (a list of
+  string), ``context`` and ``request``.  It should return ``True`` if
+  the current user implied by the request has at least one of the roles
+  in the ``context``, ``False`` otherwise.
 
 A ``workflow`` tag may contain ``transition`` and ``state`` tags.  A
 workflow declared via ZCML is unique amongst all workflows defined if
@@ -322,6 +338,13 @@ The ``alias`` tag may only be used within a ``state`` tag.  The
 ``state_attr`` attribute that matches the state's name *or any of its
 aliases*, it will be considered to be in that state, according to
 e.g. ``workflow.state_of``, etc.
+
+The ``role`` Tag
+----------------
+The ``role`` tag which may occur within the ``transition`` tag allows
+to specify role guards. The only attribute available is ``name``.
+The roles specified within a ``transition`` are passed as a list of strings
+to the ``roles_checker`` which can be specified for the workflow.
 
 .. _callbacks:
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -109,7 +109,7 @@ use some of these APIs you need a "request" object.  This object is
 available in :mod:`repoze.bfg` views as the "request" parameter to the
 view.  Your web framework may have another kind of request object
 obtained from another place.  If none of your workflows use a
-``permission_checker``, you can pass ``None`` as the request object.
+``permission_checker`` or ``roles_checker``, you can pass ``None`` as the request object.
 
 Here is how you initialize a piece of content to the initial workflow
 state:
@@ -180,7 +180,7 @@ current
 transitions
 
   A sequence of transition dictionaries; if any of the transitions is
-  not allowed due to a permission violation, it will not show up in
+  not allowed due to a permission violation or insuficient roles, it will not show up in
   this list.
 
 You can also obtain state information about a nonexistent object
@@ -193,9 +193,9 @@ content object) using ``state_info``:
    state_info = workflow.state_info(None, request, context=someotherobject)
 
 This will return the same list of dictionaries, except the ``current``
-flag will always be false.  Permissions used to compute the allowed
+flag will always be false.  Permissions and roles used to compute the allowed
 transitions will be computed against the ``context`` (the ``context``
-will be passed to the permission checker instead of any particular
+will be passed to the permission checker resp. the roles checker instead of any particular
 content object).
 
 You can obtain transition information for a piece of content using the

--- a/repoze/workflow/meta.zcml
+++ b/repoze/workflow/meta.zcml
@@ -33,6 +33,14 @@
       handler="repoze.workflow.zcml.guard_function"
       />
 
+   <meta:directive
+      name="role"
+      namespace="http://namespaces.repoze.org/bfg"
+      usedIn="repoze.workflow.zcml.ITransitionDirective"
+      schema="repoze.workflow.zcml.IRoleDirective"
+      handler="repoze.workflow.zcml.role"
+      />
+
   <meta:groupingDirective
       name="state"
       namespace="http://namespaces.repoze.org/bfg"

--- a/repoze/workflow/tests/fixtures/configure.zcml
+++ b/repoze/workflow/tests/fixtures/configure.zcml
@@ -11,6 +11,7 @@
             content_types=".dummy.IContent .dummy.IContent2"
             elector=".dummy.elector"
             permission_checker=".dummy.has_permission"
+            roles_checker=".dummy.has_role"
     >
 
         <state name="private"

--- a/repoze/workflow/tests/fixtures/configure.zcml
+++ b/repoze/workflow/tests/fixtures/configure.zcml
@@ -45,6 +45,7 @@
         <transition
                 name="private_to_public"
                 callback=".dummy.callback"
+                callback_after=".dummy.callback_after"
                 from_state="private"
                 to_state="public"
                 permission="moderate"

--- a/repoze/workflow/tests/fixtures/configure.zcml
+++ b/repoze/workflow/tests/fixtures/configure.zcml
@@ -1,54 +1,63 @@
 <configure xmlns="http://namespaces.repoze.org/bfg">
 
-<include package="repoze.workflow" file="meta.zcml"/>
+    <include package="repoze.workflow" file="meta.zcml"/>
 
-<workflow
-   type="security"
-   name="the workflow"
-   description="The workflow which is of the testing fixtures package"
-   state_attr="state"
-   initial_state="private"
-   content_types=".dummy.IContent .dummy.IContent2"
-   elector=".dummy.elector"
-   permission_checker=".dummy.has_permission"
-   >
+    <workflow
+            type="security"
+            name="the workflow"
+            description="The workflow which is of the testing fixtures package"
+            state_attr="state"
+            initial_state="private"
+            content_types=".dummy.IContent .dummy.IContent2"
+            elector=".dummy.elector"
+            permission_checker=".dummy.has_permission"
+    >
 
-   <state name="private" 
-      callback=".dummy.callback" title="Private">
-        <key name="description" value="Nobody can see it"/>
-        <alias name="supersecret"/>
-   </state>
+        <state name="private"
+               callback=".dummy.callback" title="Private">
+            <key name="description" value="Nobody can see it"/>
+            <alias name="supersecret"/>
+        </state>
 
-   <state name="public"
-      callback=".dummy.callback" title="Public">
-     <key name="description" value="Everybody can see it"/>
-   </state>
+        <state name="public"
+               callback=".dummy.callback" title="Public">
+            <key name="description" value="Everybody can see it"/>
+        </state>
 
-   <transition
-      name="public_to_private"
-      callback=".dummy.callback"
-      from_state="public"
-      to_state="private"
-      permission="moderate"
-      />
+        <transition
+                name="public_to_private"
+                callback=".dummy.callback"
+                from_state="public"
+                to_state="private"
+                permission="moderate"
+        />
 
-   <transition
-     name="unavailable_public_to_private"
-     callback=".dummy.callback"
-     from_state="public"
-     to_state="private"
-     permission="moderate">
-         <guard function=".dummy.never" />
-    </transition>
+        <transition
+                name="unavailable_public_to_private"
+                callback=".dummy.callback"
+                from_state="public"
+                to_state="private"
+                permission="moderate">
+            <guard function=".dummy.never"/>
+        </transition>
 
-   <transition
-      name="private_to_public"
-      callback=".dummy.callback"
-      from_state="private"
-      to_state="public"
-      permission="moderate"
-      />
+        <transition
+                name="private_to_public"
+                callback=".dummy.callback"
+                from_state="private"
+                to_state="public"
+                permission="moderate"
+        />
 
-</workflow>
-      
+        <transition
+                name="private_to_public_by_role"
+                from_state="private"
+                to_state="public"
+        >
+            <role name="admin"/>
+            <role name="editor"/>
+        </transition>
+
+    </workflow>
+
 </configure>

--- a/repoze/workflow/tests/fixtures/dummy.py
+++ b/repoze/workflow/tests/fixtures/dummy.py
@@ -16,6 +16,9 @@ class Content(object):
 def callback(context, transition):
     """ """
 
+def callback_after(context, transition):
+    """"""
+
 def never(context, transition):  # pragma: NO COVER
     raise WorkflowError("This is never allowed")
 

--- a/repoze/workflow/tests/fixtures/dummy.py
+++ b/repoze/workflow/tests/fixtures/dummy.py
@@ -23,3 +23,6 @@ def elector(context): return True
 
 def has_permission(permission, context, request):
     """ """
+
+def has_role(roles, context, request):
+    """"""

--- a/repoze/workflow/tests/test_zcml.py
+++ b/repoze/workflow/tests/test_zcml.py
@@ -333,7 +333,7 @@ class TestFixtureApp(unittest.TestCase):
                 },
             })
         transitions = workflow._transition_data
-        self.assertEqual(len(transitions), 3)
+        self.assertEqual(len(transitions), 4)
         self.assertEqual(transitions['private_to_public'],
             {'from_state': _u('private'),
              'callback': callback,

--- a/repoze/workflow/tests/test_zcml.py
+++ b/repoze/workflow/tests/test_zcml.py
@@ -377,10 +377,7 @@ class TestFixtureApp(unittest.TestCase):
         self.assertEqual(transitions['private_to_public_by_role'],
             {'from_state': _u('private'),
              'callback': None,
-<<<<<<< HEAD
-=======
              'callback_after': None,
->>>>>>> master
              'guards': [],
              'name': _u('private_to_public_by_role'),
              'to_state': _u('public'),

--- a/repoze/workflow/tests/test_zcml.py
+++ b/repoze/workflow/tests/test_zcml.py
@@ -1,6 +1,9 @@
 import unittest
 from zope.testing.cleanup import cleanUp
 
+from repoze.workflow.tests.fixtures.dummy import callback_after
+
+
 class TestWorkflowDirective(unittest.TestCase):
     def setUp(self):
         cleanUp()
@@ -203,19 +206,21 @@ class TestTransitionDirective(unittest.TestCase):
         return TransitionDirective
 
     def _makeOne(self, context=None, name=None, from_state=None,
-                 to_state=None, callback=None, permission=None):
+                 to_state=None, callback=None, permission=None, callback_after=None):
         return self._getTargetClass()(context, name, from_state,
-                                      to_state, callback, permission)
+                                      to_state, callback,
+                                      permission, callback_after=callback_after)
 
     def test_ctor(self):
         directive = self._makeOne('context', 'name', 'from_state',
-                                  'to_state', 'callback', 'permission')
+                                  'to_state', 'callback', 'permission', callback_after='callback_after')
         self.assertEqual(directive.context, 'context')
         self.assertEqual(directive.name, 'name')
         self.assertEqual(directive.callback, 'callback')
         self.assertEqual(directive.from_state, 'from_state')
         self.assertEqual(directive.to_state, 'to_state')
         self.assertEqual(directive.permission, 'permission')
+        self.assertEqual(directive.callback_after, 'callback_after')
         self.assertEqual(directive.extras, {})
 
     def test_after(self):
@@ -339,6 +344,7 @@ class TestFixtureApp(unittest.TestCase):
         self.assertEqual(transitions['private_to_public'],
             {'from_state': _u('private'),
              'callback': callback,
+             'callback_after': callback_after,
              'guards': [],
              'name': _u('private_to_public'),
              'to_state': _u('public'),
@@ -349,6 +355,7 @@ class TestFixtureApp(unittest.TestCase):
         self.assertEqual(transitions['unavailable_public_to_private'],
             {'from_state': _u('public'),
              'callback': callback,
+             'callback_after': None,
              'guards': [dummy.never],
              'name': _u('unavailable_public_to_private'),
              'to_state': _u('private'),
@@ -359,6 +366,7 @@ class TestFixtureApp(unittest.TestCase):
         self.assertEqual(transitions['public_to_private'],
              {'from_state': _u('public'),
               'callback': callback,
+              'callback_after': None,
               'guards': [],
               'name': 'public_to_private',
               'to_state': _u('private'),
@@ -369,6 +377,7 @@ class TestFixtureApp(unittest.TestCase):
         self.assertEqual(transitions['private_to_public_by_role'],
             {'from_state': _u('private'),
              'callback': None,
+             'callback_after': None,
              'guards': [],
              'name': _u('private_to_public_by_role'),
              'to_state': _u('public'),

--- a/repoze/workflow/tests/test_zcml.py
+++ b/repoze/workflow/tests/test_zcml.py
@@ -340,7 +340,8 @@ class TestFixtureApp(unittest.TestCase):
              'guards': [],
              'name': _u('private_to_public'),
              'to_state': _u('public'),
-             'permission':'moderate',
+             'roles': [],
+             'permission': 'moderate',
              'title': 'private_to_public',
             }),
         self.assertEqual(transitions['unavailable_public_to_private'],
@@ -350,6 +351,7 @@ class TestFixtureApp(unittest.TestCase):
              'name': _u('unavailable_public_to_private'),
              'to_state': _u('private'),
              'permission':_u('moderate'),
+             'roles': [],
              'title': _u('unavailable_public_to_private'),
             }),
         self.assertEqual(transitions['public_to_private'],
@@ -359,8 +361,19 @@ class TestFixtureApp(unittest.TestCase):
               'name': 'public_to_private',
               'to_state': _u('private'),
               'permission':'moderate',
+              'roles': [],
               'title': 'public_to_private'}
             )
+        self.assertEqual(transitions['private_to_public_by_role'],
+            {'from_state': _u('private'),
+             'callback': None,
+             'guards': [],
+             'name': _u('private_to_public_by_role'),
+             'to_state': _u('public'),
+             'permission': None,
+             'roles': ['admin', 'editor'],
+             'title': 'private_to_public_by_role',
+            }),
 
 class TestRegisterWorkflow(unittest.TestCase):
     def setUp(self):

--- a/repoze/workflow/tests/test_zcml.py
+++ b/repoze/workflow/tests/test_zcml.py
@@ -301,6 +301,7 @@ class TestFixtureApp(unittest.TestCase):
         from repoze.workflow.tests.fixtures.dummy import IContent
         from repoze.workflow.tests.fixtures.dummy import elector
         from repoze.workflow.tests.fixtures.dummy import has_permission
+        from repoze.workflow.tests.fixtures.dummy import has_role
         from repoze.workflow._compat import text_ as _u
         xmlconfig.file('configure.zcml', package, execute=True)
         sm = getSiteManager()
@@ -315,6 +316,7 @@ class TestFixtureApp(unittest.TestCase):
         self.assertEqual(workflow.description, 'The workflow which is of the '
                          'testing fixtures package')
         self.assertEqual(workflow.permission_checker, has_permission)
+        self.assertEqual(workflow.roles_checker, has_role)
         self.assertEqual(
             workflow._state_aliases,
             {'supersecret':'private'},

--- a/repoze/workflow/tests/test_zcml.py
+++ b/repoze/workflow/tests/test_zcml.py
@@ -82,12 +82,12 @@ class TestWorkflowDirective(unittest.TestCase):
              {'from_state': 'private', 'callback': None,
               'guards': [], 'name': 'make_public', 
               'to_state': 'public', 'permission':None, 
-              'title': 'make_public'},
+              'title': 'make_public', 'roles': []},
              'make_private':
              {'from_state': 'private', 'callback': None,
               'guards': [], 'name': 'make_private', 
               'to_state': 'public', 'permission':None, 
-              'title': 'Retract'},
+              'title': 'Retract', 'roles': []},
              })
         self.assertEqual(workflow.initial_state, 'public')
 
@@ -122,12 +122,12 @@ class TestWorkflowDirective(unittest.TestCase):
              {'from_state': 'private', 'callback': None,
               'guards': [], 'name': 'make_public', 
               'to_state': 'public', 'permission':None, 
-              'title': 'make_public'},
+              'title': 'make_public', 'roles': []},
              'make_private':
              {'from_state': 'private', 'callback': None,
               'guards': [], 'name': 'make_private', 
               'to_state': 'public', 'permission':None, 
-              'title': 'Retract'},
+              'title': 'Retract', 'roles': []},
              }
             )
         self.assertEqual(workflow.initial_state, 'public')
@@ -458,3 +458,4 @@ class DummyTransition:
         self.title = title
         self.extras = extras
         self.guards = []
+        self.roles = []

--- a/repoze/workflow/workflow.py
+++ b/repoze/workflow/workflow.py
@@ -59,7 +59,7 @@ class Workflow(object):
             self._state_aliases[alias] = state_name
 
     def add_transition(self, transition_name, from_state, to_state,
-                       callback=None, permission=None, title=None, **kw):
+                       callback=None, permission=None, title=None, roles=None,**kw):
         """ Add a transition to the FSM.  ``**kw`` must not contain
         any of the keys ``from_state``, ``name``, ``to_state``, or
         ``callback``; these are reserved for internal use."""
@@ -80,6 +80,7 @@ class Workflow(object):
         transition['to_state'] = to_state
         transition['callback'] = callback
         transition['permission'] = permission
+        transition['roles'] = roles or []
         if title is None:
             title = transition_name
         transition['title'] = title

--- a/repoze/workflow/workflow.py
+++ b/repoze/workflow/workflow.py
@@ -59,11 +59,7 @@ class Workflow(object):
             self._state_aliases[alias] = state_name
 
     def add_transition(self, transition_name, from_state, to_state,
-<<<<<<< HEAD
-                       callback=None, permission=None, title=None, roles=None,**kw):
-=======
                        callback=None, permission=None, title=None, roles=None, callback_after=None, **kw):
->>>>>>> master
         """ Add a transition to the FSM.  ``**kw`` must not contain
         any of the keys ``from_state``, ``name``, ``to_state``, or
         ``callback``; these are reserved for internal use."""

--- a/repoze/workflow/zcml.py
+++ b/repoze/workflow/zcml.py
@@ -63,14 +63,15 @@ class IWorkflowDirective(Interface):
     content_types = Tokens(title=_u('content_types'), required=False,
                            value_type=GlobalObject())
     elector = GlobalObject(title=_u('elector'), required=False)
-    permission_checker = GlobalObject(title=_u('checker'), required=False)
+    permission_checker = GlobalObject(title=_u('permission checker'), required=False)
     description = TextLine(title=_u('description'), required=False)
+    roles_checker = GlobalObject(title=_u('roles checker'), required=False)
 
 @implementer(IConfigurationContext, IWorkflowDirective)
 class WorkflowDirective(GroupingContextDecorator):
     def __init__(self, context, type, name, state_attr, initial_state,
                  content_types=(), elector=None, permission_checker=None,
-                 description=''):
+                 description='', roles_checker=None):
         self.context = context
         self.type = type
         self.name = name
@@ -84,6 +85,7 @@ class WorkflowDirective(GroupingContextDecorator):
         self.description = description
         self.transitions = [] # mutated by subdirectives
         self.states = [] # mutated by subdirectives
+        self.roles_checker = roles_checker
 
     def after(self):
         def register(content_type):

--- a/repoze/workflow/zcml.py
+++ b/repoze/workflow/zcml.py
@@ -111,13 +111,9 @@ class WorkflowDirective(GroupingContextDecorator):
                                             transition.callback,
                                             transition.permission,
                                             transition.title,
-<<<<<<< HEAD
-                                            guards=transition.guards,                                            roles=transition.roles,
-=======
                                             guards=transition.guards,
                                             roles=transition.roles,
                                             callback_after=transition.callback_after,
->>>>>>> master
                                             **transition.extras)
                 except WorkflowError as why:
                     raise ConfigurationError(str(why))

--- a/repoze/workflow/zcml.py
+++ b/repoze/workflow/zcml.py
@@ -109,6 +109,7 @@ class WorkflowDirective(GroupingContextDecorator):
                                             transition.permission,
                                             transition.title,
                                             guards=transition.guards,
+                                            roles=transition.roles,
                                             **transition.extras)
                 except WorkflowError as why:
                     raise ConfigurationError(str(why))

--- a/repoze/workflow/zcml.py
+++ b/repoze/workflow/zcml.py
@@ -48,6 +48,7 @@ class ITransitionDirective(Interface):
     permission = TextLine(title=_u('permission'), required=False)
     title = TextLine(title=_u('title'), required=False)
     callback = GlobalObject(title=_u('callback'), required=False)
+    callback_after = GlobalObject(title=_u('callback_after'), required=False)
 
 class IStateDirective(Interface):
     """ The interface for a state directive """
@@ -112,6 +113,7 @@ class WorkflowDirective(GroupingContextDecorator):
                                             transition.title,
                                             guards=transition.guards,
                                             roles=transition.roles,
+                                            callback_after=transition.callback_after,
                                             **transition.extras)
                 except WorkflowError as why:
                     raise ConfigurationError(str(why))
@@ -145,7 +147,7 @@ class TransitionDirective(GroupingContextDecorator):
     """
 
     def __init__(self, context, name, from_state, to_state,
-                 callback=None, permission=None, title=None):
+                 callback=None, permission=None, title=None, callback_after=None):
         self.context = context
         self.name = name
         if not from_state:
@@ -158,6 +160,7 @@ class TransitionDirective(GroupingContextDecorator):
         self.guards = []
         self.roles = []
         self.extras = {} # mutated by subdirectives
+        self.callback_after = callback_after
 
     def after(self):
         self.context.transitions.append(self)

--- a/repoze/workflow/zcml.py
+++ b/repoze/workflow/zcml.py
@@ -27,6 +27,10 @@ class IGuardDirective(Interface):
     """ A directive for a guard on a transition. """
     function = GlobalObject(title=_u('enter guard function'), required=True)
 
+class IRoleDirective(Interface):
+    """ The interface for a key/value pair subdirective """
+    name = TextLine(title=_u('name'), required=True)
+
 class IKeyValueDirective(Interface):
     """ The interface for a key/value pair subdirective """
     name = TextLine(title=_u('key'), required=True)
@@ -149,6 +153,7 @@ class TransitionDirective(GroupingContextDecorator):
         self.permission = permission
         self.title = title
         self.guards = []
+        self.roles = []
         self.extras = {} # mutated by subdirectives
 
     def after(self):
@@ -169,6 +174,9 @@ class StateDirective(GroupingContextDecorator):
 
 def guard_function(context, function):
     context.guards.append(function)
+
+def role(context, name):
+    context.roles.append(name)
 
 def key_value_pair(context, name, value):
     ob = context.context

--- a/repoze/workflow/zcml.py
+++ b/repoze/workflow/zcml.py
@@ -91,7 +91,7 @@ class WorkflowDirective(GroupingContextDecorator):
         def register(content_type):
             workflow = Workflow(self.state_attr, self.initial_state,
                                 self.permission_checker, self.name,
-                                self.description)
+                                self.description, roles_checker=self.roles_checker)
             for state in self.states:
                 try:
                     workflow.add_state(state.name,

--- a/repoze/workflow/zcml.py
+++ b/repoze/workflow/zcml.py
@@ -110,8 +110,7 @@ class WorkflowDirective(GroupingContextDecorator):
                                             transition.callback,
                                             transition.permission,
                                             transition.title,
-                                            guards=transition.guards,
-                                            roles=transition.roles,
+                                            guards=transition.guards,                                            roles=transition.roles,
                                             **transition.extras)
                 except WorkflowError as why:
                     raise ConfigurationError(str(why))

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
     url="http://www.repoze.org",
     license="BSD-derived (http://www.repoze.org/LICENSE.txt)",
     packages=find_packages(),
+    package_data={'': ['*.zcml']},
     include_package_data=True,
     namespace_packages=['repoze'],
     zip_safe=False,


### PR DESCRIPTION
This pull request adds role guards for transitions:

```
<transition ....>
   <role name="admin"/>
   <tole name="editor"/>
</transition>
```

These roles can be checked using a ``roles_checker`` in analogy to the existing ``permission_checker`` attribute
    